### PR TITLE
Updating to Clasp 2.4.1

### DIFF
--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Install clasp
         id: install-clasp
-        run: sudo npm install @google/clasp@2.3.2 -g
+        run: sudo npm install @google/clasp@2.4.1 -g
 
       - name: Write CLASPRC_JSON secret to .clasprc.json file
         id: write-clasprc


### PR DESCRIPTION
This latest [2.4.1 release](https://github.com/google/clasp/releases/tag/v2.4.1) of clasp resolves the login issues previously added in 2.4.0

https://github.com/google/clasp/pull/862
